### PR TITLE
fix: wrong parameters in create users request

### DIFF
--- a/tasks/users.js
+++ b/tasks/users.js
@@ -40,7 +40,7 @@ async function createRoles(context) {
       app_access: true,
    }));
 
-   const createdRoles = await apiV9.post('/roles', rolesV9, { limit: -1 });
+   const createdRoles = await apiV9.post('/roles', rolesV9, { params: { limit: -1 } });
 
    context.roleMap = {};
 
@@ -70,7 +70,7 @@ async function createUsers(context) {
       token: user.token,
    }));
 
-   const createdUsers = await apiV9.post('/users', usersV9, { limit: -1 });
+   const createdUsers = await apiV9.post('/users', usersV9, { params: { limit: -1 } });
 
    context.userMap = {};
 


### PR DESCRIPTION
I found that when the users count is more than `100` the process will crash when trying to assign user ids to the `context.userMap`, this may fix #5 as well, not sure though due to missing details about #5.