### PR TITLE
Adds support for skipping collections from the migration

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ import { migrateUsers } from "./tasks/users.js";
 import { migrateData } from "./tasks/data.js";
 
 const commandLineOptions = commandLineArgs([
-  { name: 'skip', alias: 's', type: String, multiple: true, defaultValue: []}
+  { name: 'skipCollections', alias: 's', type: String, multiple: true, defaultValue: []}
 ]);
 
 const tasks = new Listr([

--- a/index.js
+++ b/index.js
@@ -1,14 +1,19 @@
 import Listr from "listr";
 
+import commandLineArgs from 'command-line-args';
 import { migrateSchema } from "./tasks/schema.js";
 import { migrateFiles } from "./tasks/files.js";
 import { migrateUsers } from "./tasks/users.js";
 import { migrateData } from "./tasks/data.js";
 
+const commandLineOptions = commandLineArgs([
+  { name: 'skip', alias: 's', type: String, multiple: true, defaultValue: []}
+]);
+
 const tasks = new Listr([
   {
     title: "Migrating Schema",
-    task: migrateSchema,
+    task: () => migrateSchema({skipCollections: commandLineOptions.skipCollections }),
   },
   {
     title: "Migration Files",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
+    "command-line-args": "^5.1.1",
     "listr": "^0.14.3"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -28,3 +28,7 @@ V9_URL="https://v9.example.com"
 V9_TOKEN="admin"
 ```
 3) Run the `index.js` file: `node index.js`
+    1) You can exclude collections from being migrated by using:
+    ```
+    node index.js -s <table_name> <another_table_name>
+    ```

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,9 @@ V9_URL="https://v9.example.com"
 V9_TOKEN="admin"
 ```
 3) Run the `index.js` file: `node index.js`
-    1) You can exclude collections from being migrated by using:
-    ```
-    node index.js -s <table_name> <another_table_name>
-    ```
+   
+### NOTE
+You can exclude collections/database tables from being migrated by using:
+```
+node index.js -s <table_name> <another_table_name>
+```

--- a/tasks/schema.js
+++ b/tasks/schema.js
@@ -24,7 +24,9 @@ async function downloadSchema(context) {
   const response = await apiV8.get("/collections");
   context.collections = response.data.data.filter(
     (collection) => collection.collection.startsWith("directus_") === false
-  ).filter((collection) => !context.skipCollections.includes(collection.collection));
+  ).filter(
+    (collection) => !context.skipCollections.includes(collection.collection)
+  );
 }
 
 async function migrateCollections(context) {


### PR DESCRIPTION
Besides adding support to exclude tables from being imported during the migration (example: exclude tables that are not business tables and should not be moved to the new database) but also fixes the issue that an array field with a default value fails to be created since it is now marked as "json" instead, therefor fixing #9 