### PR TITLE
(Oneliner) Adding longtext to text conversion

### DIFF
--- a/tasks/schema.js
+++ b/tasks/schema.js
@@ -143,7 +143,7 @@ function migrateCollection(collection) {
         return {
           field: details.field,
           type:
-            details.datatype?.toLowerCase() === "text"
+            details.datatype?.toLowerCase() === "text" || details.datatype?.toLowerCase() === "longtext"
               ? "text"
               : typeMap[details.type.toLowerCase()],
           meta: {


### PR DESCRIPTION
Previously, longtext schema type was converted to string which led to data not being importet for being to long.
This commit adjusts this behavior so that, they are correctly converted to the new text type.