### PR TITLE
Save context in between tasks and fix relations migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,14 @@ node_modules
 .vscode
 .env
 temp.json
+
+
+# Ignore context files except start
+context/collections.json
+context/data.json
+context/files.json
+context/relations.json
+context/roles.json
+context/schema.json
+context/users.json
+context/completed.json

--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,4 @@ temp.json
 
 
 # Ignore context files except start
-context/collections.json
-context/data.json
-context/files.json
-context/relations.json
-context/roles.json
-context/schema.json
-context/users.json
-context/completed.json
+context/state/*

--- a/context/start.json
+++ b/context/start.json
@@ -1,10 +1,13 @@
 {
   "completedSteps": {
-    "schema": "false",
-    "collections": "false",
-    "files": "false",
-    "roles": "false",
-    "users": "false",
-    "relations": "false"
-  }
+    "schema": false,
+    "collections": false,
+    "files": false,
+    "roles": false,
+    "users": false,
+    "relations": false,
+    "data": false,
+    "completed": false
+  },
+  "collectionsV9": []
 }

--- a/context/start.json
+++ b/context/start.json
@@ -5,7 +5,6 @@
     "files": "false",
     "roles": "false",
     "users": "false",
-    "data": "false",
     "relations": "false"
   }
 }

--- a/context/start.json
+++ b/context/start.json
@@ -1,0 +1,9 @@
+{
+  "completedSteps": {
+    "schema": "false",
+    "files": "false",
+    "users": "false",
+    "data": "false",
+    "relations": "false"
+  }
+}

--- a/context/start.json
+++ b/context/start.json
@@ -5,6 +5,7 @@
     "files": false,
     "roles": false,
     "users": false,
+    "relationsv8": false,
     "relations": false,
     "data": false,
     "completed": false

--- a/context/start.json
+++ b/context/start.json
@@ -1,6 +1,7 @@
 {
   "completedSteps": {
     "schema": "false",
+    "collections": "false",
     "files": "false",
     "users": "false",
     "data": "false",

--- a/context/start.json
+++ b/context/start.json
@@ -3,6 +3,7 @@
     "schema": "false",
     "collections": "false",
     "files": "false",
+    "roles": "false",
     "users": "false",
     "data": "false",
     "relations": "false"

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ const tasks = new Listr([
 export async function writeContext(context, section) {
   context.completedSteps[section] = true;
   await fs.promises.writeFile(
-    `./context/${section}.json`,
+    `./context/state/${section}.json`,
     JSON.stringify(context)
   );
 }

--- a/index.js
+++ b/index.js
@@ -54,7 +54,9 @@ const tasks = new Listr([
   },
   {
     title: "Migrating Relations",
-    skip: (context) => context.completedSteps.relations === true,
+    skip: (context) =>
+      context.completedSteps.relationsv8 === true &&
+      context.completedSteps.relations === true,
     task: migrateRelations,
   },
   {

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ const tasks = new Listr([
   },
   {
     title: "Migrating Users",
-		skip: context => context.completedSteps.users === true,
+		skip: context => context.completedSteps.roles === true && context.completedSteps.users === true,
     task: migrateUsers,
   },
   {

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ const tasks = new Listr([
   },
   {
     title: "Migrating Schema",
+		skip: context => context.completedSteps.schema === true,
     task: (context) => {
       context.skipCollections = commandLineOptions.skipCollections;
       return migrateSchema(context);
@@ -38,14 +39,17 @@ const tasks = new Listr([
   },
   {
     title: "Migration Files",
+		skip: context => context.completedSteps.files === true,
     task: migrateFiles,
   },
   {
     title: "Migrating Users",
+		skip: context => context.completedSteps.users === true,
     task: migrateUsers,
   },
   {
     title: "Migrating Data",
+		skip: context => context.completedSteps.data === true,
     task: migrateData,
   },
 ]);

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import Listr from "listr";
 
 import commandLineArgs from "command-line-args";
-import * as fs from 'fs';
+import * as fs from "fs";
 import { migrateSchema } from "./tasks/schema.js";
 import { migrateFiles } from "./tasks/files.js";
 import { migrateUsers } from "./tasks/users.js";
@@ -9,20 +9,20 @@ import { migrateData } from "./tasks/data.js";
 import { migrateRelations } from "./tasks/relations.js";
 
 const commandLineOptions = commandLineArgs([
-	{
-		name: "skipCollections",
-		alias: "s",
-		type: String,
-		multiple: true,
-		defaultValue: [],
-	},
-	{
-		name: "useContext",
-		alias: "c",
-		type: String,
-		multiple: false,
-		defaultValue: './context/start.json'
-	},
+  {
+    name: "skipCollections",
+    alias: "s",
+    type: String,
+    multiple: true,
+    defaultValue: [],
+  },
+  {
+    name: "useContext",
+    alias: "c",
+    type: String,
+    multiple: false,
+    defaultValue: "./context/start.json",
+  },
 ]);
 
 const tasks = new Listr([
@@ -32,7 +32,9 @@ const tasks = new Listr([
   },
   {
     title: "Migrating Schema",
-		skip: context => context.completedSteps.schema === true && context.completedSteps.collections === true,
+    skip: (context) =>
+      context.completedSteps.schema === true &&
+      context.completedSteps.collections === true,
     task: (context) => {
       context.skipCollections = commandLineOptions.skipCollections;
       return migrateSchema(context);
@@ -40,22 +42,24 @@ const tasks = new Listr([
   },
   {
     title: "Migration Files",
-		skip: context => context.completedSteps.files === true,
+    skip: (context) => context.completedSteps.files === true,
     task: migrateFiles,
   },
   {
     title: "Migrating Users",
-		skip: context => context.completedSteps.roles === true && context.completedSteps.users === true,
+    skip: (context) =>
+      context.completedSteps.roles === true &&
+      context.completedSteps.users === true,
     task: migrateUsers,
   },
   {
     title: "Migrating Relations",
-    skip: context => context.completedSteps.relations === true,
+    skip: (context) => context.completedSteps.relations === true,
     task: migrateRelations,
   },
   {
     title: "Migrating Data",
-		skip: context => context.completedSteps.data === true,
+    skip: (context) => context.completedSteps.data === true,
     task: migrateData,
   },
 
@@ -67,33 +71,34 @@ const tasks = new Listr([
 
 export async function writeContext(context, section) {
   context.completedSteps[section] = true;
-	await fs.promises.writeFile(`./context/${section}.json`, JSON.stringify(context));
+  await fs.promises.writeFile(
+    `./context/${section}.json`,
+    JSON.stringify(context)
+  );
 }
 
 async function setupContext(context) {
-	const contextJSON = await fs.promises.readFile(
+  const contextJSON = await fs.promises.readFile(
     commandLineOptions.useContext,
-    'utf8'
+    "utf8"
   );
-  console.log('Loading context')
+  console.log("Loading context");
   const fetchedContext = JSON.parse(contextJSON);
   Object.entries(fetchedContext).forEach(([key, value]) => {
     context[key] = value;
   });
-	console.log(
-		`✨ Loaded context succesfully`
-	)
+  console.log(`✨ Loaded context succesfully`);
 }
 
 console.log(
-	`✨ Migrating ${process.env.V8_URL} (v8) to ${process.env.V9_URL} (v9)...`
+  `✨ Migrating ${process.env.V8_URL} (v8) to ${process.env.V9_URL} (v9)...`
 );
 
 tasks
-	.run()
-	.then(() => {
-		console.log("✨ All set! Migration successful.");
-	})
-	.catch((err) => {
-		console.error(err);
-	});
+  .run()
+  .then(() => {
+    console.log("✨ All set! Migration successful.");
+  })
+  .catch((err) => {
+    console.error(err);
+  });

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ import { migrateSchema } from "./tasks/schema.js";
 import { migrateFiles } from "./tasks/files.js";
 import { migrateUsers } from "./tasks/users.js";
 import { migrateData } from "./tasks/data.js";
+import { migrateRelations } from "./tasks/relations.js";
 
 const commandLineOptions = commandLineArgs([
 	{
@@ -48,9 +49,19 @@ const tasks = new Listr([
     task: migrateUsers,
   },
   {
+    title: "Migrating Relations",
+    skip: context => context.completedSteps.relations === true,
+    task: migrateRelations,
+  },
+  {
     title: "Migrating Data",
 		skip: context => context.completedSteps.data === true,
     task: migrateData,
+  },
+
+  {
+    title: "Save final context",
+    task: (context) => writeContext(context, "completed"),
   },
 ]);
 
@@ -64,7 +75,7 @@ async function setupContext(context) {
     commandLineOptions.useContext,
     'utf8'
   );
-  console.log('Loading context', contextJSON);
+  console.log('Loading context')
   const fetchedContext = JSON.parse(contextJSON);
   Object.entries(fetchedContext).forEach(([key, value]) => {
     context[key] = value;

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const tasks = new Listr([
   },
   {
     title: "Migrating Schema",
-		skip: context => context.completedSteps.schema === true,
+		skip: context => context.completedSteps.schema === true && context.completedSteps.collections === true,
     task: (context) => {
       context.skipCollections = commandLineOptions.skipCollections;
       return migrateSchema(context);

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Migration Tool
 
-Migrate from a v8 instance to v9 instance. 
+Migrate from a v8 instance to v9 instance.
 
 This tool will copy over:
 
@@ -39,9 +39,17 @@ V9_TOKEN="admin"
 ```
 3) Run `npm install`
 4) Run the `index.js` file: `node index.js`
+
+
+### Commandline Options
 ***
-You can exclude collections/database tables from being migrated by using:
+You can exclude collections/database tables from being migrated by using the `-s` or `--skipCollections` flag:
 ```
 node index.js -s <table_name> <another_table_name>
+```
+***
+You can pass a context file to resume from a specific point or to modify the data manually that you want to use for the migration by using the `-c` or `--useContext` flag:
+```
+node index.js -c <path_to_context>
 ```
 ***

--- a/tasks/data.js
+++ b/tasks/data.js
@@ -72,8 +72,8 @@ async function insertBatch(collection, page, context, task) {
 
 	const systemRelationsForCollection = context.relations.filter((relation) => {
 		return (
-			relation.many_collection === collection.collection &&
-			relation.one_collection.startsWith("directus_")
+			relation?.meta?.many_collection === collection.collection &&
+			relation?.meta?.one_collection.startsWith("directus_")
 		);
 	});
 
@@ -82,12 +82,12 @@ async function insertBatch(collection, page, context, task) {
 			? recordsResponse.data.data
 			: recordsResponse.data.data.map((item) => {
 					for (const systemRelation of systemRelationsForCollection) {
-						if (systemRelation.one_collection === "directus_users") {
-							item[systemRelation.many_field] =
-								context.userMap[item[systemRelation.many_field]];
-						} else if (systemRelation.one_collection === "directus_files") {
-							item[systemRelation.many_field] =
-								context.fileMap[item[systemRelation.many_field]];
+						if (systemRelation?.meta?.one_collection === "directus_users") {
+							item[systemRelation?.meta?.many_field] =
+								context.userMap[item[systemRelation?.meta?.many_field]];
+						} else if (systemRelation?.meta?.one_collection === "directus_files") {
+							item[systemRelation?.meta?.many_field] =
+								context.fileMap[item[systemRelation?.meta?.many_field]];
 						}
 					}
 

--- a/tasks/data.js
+++ b/tasks/data.js
@@ -29,9 +29,38 @@ async function getCounts(context) {
 	}
 }
 
+// This is definitely a hack to achieve first adding items of collections that have dependencies in other collections i.e m2m, o2m
+// FIXME: Implement a more robust solution to sort collections based on their dependencies, or swap to a different way to seed the data
+function moveJunctionCollectionsBack(a,b) {
+	if (a.note === "Junction Collection" || b.note === "Junction Collection") {
+		if (a.note === "Junction Collection") {
+			return 1;
+		}
+
+		if (b.note === "Junction Collection") {
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+function moveManyToOne(a,b) {
+	if ( Object.values(a.fields).find(element => element.interface === 'many-to-one') ) {
+		return 1;
+	}
+
+	if ( Object.values(b.fields).find(element => element.interface === 'many-to-one') ) {
+		return -1;
+	}
+
+	return 0;
+}
+
 async function insertData(context) {
+	let sortedCollections = context.collections.sort(moveManyToOne).sort(moveJunctionCollectionsBack);
 	return new Listr(
-		context.collections.map((collection) => ({
+		sortedCollections.map((collection) => ({
 			title: collection.collection,
 			task: insertCollection(collection),
 		}))
@@ -102,6 +131,7 @@ async function insertBatch(collection, page, context, task) {
 		}
 	} catch (err) {
 		console.log(err.response.data);
+		throw Error("Data migration failed. Check directus logs for most insight.")
 	}
 }
 

--- a/tasks/files.js
+++ b/tasks/files.js
@@ -1,5 +1,6 @@
 import Listr from "listr";
 import { apiV8, apiV9 } from "../api.js";
+import { writeContext } from "../index.js";
 
 export async function migrateFiles(context) {
 	return new Listr([
@@ -11,6 +12,10 @@ export async function migrateFiles(context) {
 			title: "Uploading Files",
 			task: uploadFiles,
 		},
+		{
+      title: "Saving context",
+      task: () => writeContext(context, "files")
+    },
 	]);
 }
 

--- a/tasks/relations.js
+++ b/tasks/relations.js
@@ -1,0 +1,67 @@
+import Listr from "listr";
+import { apiV8, apiV9 } from "../api.js";
+import { writeContext } from "../index.js";
+
+export async function migrateRelations(context) {
+  return new Listr([
+    {
+      title: "Migrating Relations",
+      task: () => migrateRelationsData(context),
+    },
+    {
+      title: "Saving Relations context",
+      task: () => writeContext(context, "relations"),
+    },
+  ]);
+}
+
+async function migrateRelationsData(context) {
+  const relations = await apiV8.get("/relations", { params: { limit: -1 } });
+  const relationsV9 = relations.data.data
+    .filter((relation) => {
+      return (
+        (relation.collection_many.startsWith("directus_") &&
+          relation.collection_one.startsWith("directus_")) === false
+      );
+    })
+    .map((relation) => ({
+      meta: {
+        many_collection: relation.collection_many,
+        many_field: relation.field_many,
+        one_collection: relation.collection_one,
+        one_field: relation.field_one,
+        junction_field: relation.junction_field,
+      },
+      field: relation.field_many,
+      collection: relation.collection_many,
+      related_collection: relation.collection_one,
+      schema: null,
+    }));
+
+  const systemFields = context.collections
+    .map((collection) =>
+      Object.values(collection.fields)
+        .filter((details) => {
+          return details.type === "file" || details.type.startsWith("user");
+        })
+        .map((field) => ({
+          meta: {
+            many_field: field.field,
+            many_collection: collection.collection,
+            one_collection:
+              field.type === "file" ? "directus_files" : "directus_users",
+          },
+          field: field.field,
+          collection: collection.collection,
+          related_collection:  field.type === "file" ? "directus_files" : "directus_users",
+          schema: null,
+        }))
+    )
+    .flat();
+
+  for (const relation of [...relationsV9, ...systemFields]) {
+    await apiV9.post("/relations", relation);
+  }
+
+  context.relations = [...relationsV9, ...systemFields];
+}

--- a/tasks/schema.js
+++ b/tasks/schema.js
@@ -158,7 +158,7 @@ function migrateCollection(collection) {
           type:
             details.datatype?.toLowerCase() === "text" || details.datatype?.toLowerCase() === "longtext"
               ? "text"
-              : typeMap[details.type.toLowerCase()],
+              : details.interface === "many-to-many" ? "m2m" : typeMap[details.type.toLowerCase()],
           meta: {
             note: details.note,
             interface: interfaceMap[(details.interface || "").toLowerCase()],
@@ -192,7 +192,11 @@ function migrateCollection(collection) {
         };
       }),
     };
+<<<<<<< HEAD
 
+=======
+    context.collectionsV9.push(collectionV9);
+>>>>>>> bc68dee... Adjust behavior of m2m fields during collection creation
     await apiV9.post("/collections", collectionV9);
   };
 
@@ -209,7 +213,7 @@ function migrateCollection(collection) {
   }
 
   function extractSpecial(details) {
-    const type = details.type.toLowerCase();
+    const type = details.interface === "many-to-many" ? "m2m" : details.type.toLowerCase();
     if (type === "alias") {
       return ["alias", "no-data"];
     }
@@ -252,6 +256,10 @@ function migrateCollection(collection) {
 
     if (type === "o2m") {
       return ["o2m"];
+    }
+
+    if (type === "m2m") {
+      return ["m2m"];
     }
 
     if (type === "m2o") {

--- a/tasks/schema.js
+++ b/tasks/schema.js
@@ -156,9 +156,14 @@ function migrateCollection(collection) {
         return {
           field: details.field,
           type:
-            details.datatype?.toLowerCase() === "text" || details.datatype?.toLowerCase() === "longtext"
+            details.datatype?.toLowerCase() === "text" ||
+            details.datatype?.toLowerCase() === "longtext"
               ? "text"
-              : details.interface === "many-to-many" ? "m2m" : typeMap[details.type.toLowerCase()],
+              : details.interface === "many-to-many"
+              ? "m2m"
+              : details.field.includes("directus_files_id")
+              ? "uuid"
+              : typeMap[details.type.toLowerCase()],
           meta: {
             note: details.note,
             interface: interfaceMap[(details.interface || "").toLowerCase()],

--- a/tasks/schema.js
+++ b/tasks/schema.js
@@ -2,16 +2,29 @@ import Listr from "listr";
 import { apiV8, apiV9 } from "../api.js";
 import { typeMap } from "../constants/type-map.js";
 import { interfaceMap } from "../constants/interface-map.js";
+import { writeContext } from "../index.js";
 
 export async function migrateSchema(context) {
   return new Listr([
     {
       title: "Downloading Schema",
+      skip: context => context.completedSteps.schema === true,
       task: () => downloadSchema(context),
     },
     {
+      title: "Saving schema context",
+      skip: context => context.completedSteps.schema === true,
+      task: () => writeContext(context, "schema")
+    },
+    {
       title: "Creating Collections",
+      skip: context => context.completedSteps.collections === true,
       task: () => migrateCollections(context),
+    },
+    {
+      title: "Saving collections context",
+      skip: context => context.completedSteps.collections === true,
+      task: () => writeContext(context, "collections")
     },
     {
       title: "Migrating Relations",

--- a/tasks/users.js
+++ b/tasks/users.js
@@ -1,24 +1,39 @@
 import Listr from "listr";
 import { apiV8, apiV9 } from "../api.js";
+import { writeContext } from "../index.js";
 
 export async function migrateUsers(context) {
 	return new Listr([
 		{
 			title: "Downloading Roles",
+			skip: context => context.completedSteps.roles === true,
 			task: downloadRoles,
 		},
 		{
 			title: "Creating Roles",
+			skip: context => context.completedSteps.roles === true,
 			task: createRoles,
 		},
 		{
+      title: "Saving Roles context",
+			skip: context => context.completedSteps.roles === true,
+      task: () => writeContext(context, "roles"),
+    },
+		{
 			title: "Downloading Users",
+			skip: context => context.completedSteps.users === true,
 			task: downloadUsers,
 		},
 		{
 			title: "Creating Users",
+			skip: context => context.completedSteps.users === true,
 			task: createUsers,
 		},
+		{
+      title: "Saving users context",
+			skip: context => context.completedSteps.users === true,
+			task: () => writeContext(context, "users"),
+    },
 	]);
 }
 


### PR DESCRIPTION
This PR includes the following changes:

- Fixes from #32 to fix relations mapping
- Saving the context in a separate file for each major tasks that modifies the context
- Fixing m2m interfaces being migrated wrongly to alias fields and not the correct type & interface as v9 should have it
- Sorting collections before migrating data based on if they are junction collections or contain a 'many-to-one' (due to foreign key constraints, we otherwise have likely failures)
- New command line option to pass in context files
- Change 'directus_files_id' in junction table to type 'uuid'

Should fix #35
Should fix #34
Should fix #31 

Includes work from @dwene @hakan-erdem-temiz <3

Next steps: 

- Write a more robust sorting or find an alternative solution
