### PR TITLE
fix typo in rich text map

### DIFF
--- a/constants/interface-map.js
+++ b/constants/interface-map.js
@@ -52,5 +52,5 @@ export const interfaceMap = {
    'user-roles': null,
    'user-updated': 'select-dropdown-m2o',
    'user': 'select-dropdown-m2o',
-   'wysiwyg': 'input-richt-text-html',
+   'wysiwyg': 'input-rich-text-html',
 }


### PR DESCRIPTION
There's a typo in the WYIWYG map, which is why Rich Text Editors don't show up