### PR TITLE
allow for custom ordering of data import

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,3 +53,11 @@ You can pass a context file to resume from a specific point or to modify the dat
 node index.js -c <path_to_context>
 ```
 ***
+
+### Specifying collection dependencies
+If the default detection of the dependencies between collections doesn't work in your case, you can manually specify it with the env variable `COLLECTION_ORDER`. Just supply a comma separated list in which order you'd need the data of your collections to be imported.
+
+```
+COLLECTION_ORDER="first_collection,second_collection,third_collection"
+```
+***

--- a/tasks/data.js
+++ b/tasks/data.js
@@ -83,8 +83,27 @@ function moveManyToOne(a,b) {
 	return 0;
 }
 
+function moveByCustomOrder(collectionOrder) {
+	return (a, b) => {
+		return collectionOrder.indexOf(a.collection) - collectionOrder.indexOf(b.collection);
+	}
+}
+
 async function insertData(context) {
-	let sortedCollections = context.collections.sort(moveManyToOne).sort(moveJunctionCollectionsBack);
+	let sortedCollections;
+
+	if (process.env.COLLECTION_ORDER) {
+		const collectionOrder = process.env.COLLECTION_ORDER
+			.split(',')
+			.map(entry => entry.trim());
+		sortedCollections = context.collections
+			.sort(moveByCustomOrder(collectionOrder))
+	} else {
+		sortedCollections = context.collections
+			.sort(moveManyToOne)
+			.sort(moveJunctionCollectionsBack)
+	}
+
 	return new Listr(
 		sortedCollections.map((collection) => ({
 			title: collection.collection,


### PR DESCRIPTION
The automatic dependency detection didn't work in my case. Rather than coming up with a complicated dependency resolution solution I chose a programmatic approach that might be helpful for others as well.

You can specify the order of data import in an env variable.