### PR TITLE
Fix migration (roles, archived items, default limit for users…)

### DIFF
--- a/tasks/data.js
+++ b/tasks/data.js
@@ -164,6 +164,9 @@ async function insertBatch(collection, page, context, task) {
 						} else if (systemRelation?.meta?.one_collection === "directus_files") {
 							item[systemRelation?.meta?.many_field] =
 								context.fileMap[item[systemRelation?.meta?.many_field]];
+						} else if (systemRelation?.meta?.one_collection === "directus_roles") {
+							item[systemRelation?.meta?.many_field] =
+								context.roleMap[item[systemRelation?.meta?.many_field]];
 						}
 					}
 

--- a/tasks/schema.js
+++ b/tasks/schema.js
@@ -203,7 +203,7 @@ function migrateCollection(collection, context) {
               ? "text"
               : details.interface === "many-to-many"
               ? "m2m"
-              : details.field.includes("directus_files_id")
+              : details.field.includes("directus_files_id") || details.interface === 'user-roles'
               ? "uuid"
               : typeMap[details.type.toLowerCase()],
           meta: {

--- a/tasks/users.js
+++ b/tasks/users.js
@@ -74,7 +74,12 @@ async function createRoles(context) {
 }
 
 async function downloadUsers(context) {
-	const response = await apiV8.get("/users");
+	const response = await apiV8.get("/users", {
+		params: {
+			limit: -1,
+			status: '*',
+		}
+	});
 	context.users = response.data.data;
 }
 


### PR DESCRIPTION
Hi there!

I've been playing with the migration tool lately and I have done a huge import thanks to it! I identified a few bugs and so here is my PR which fixes them.

I fixed three things:

**Fix roles migration: use uuid + map roles with new uuid**

Roles now use a UUID as primary key so roles needed to be mapped. I added a hard check for the field type.

**Remove default limit when fetching users and fetch archived users**

The default limit is 200 items. If you have more than 200 users, some won't be imported. The migration tool will certainly fail later because of a broken foreign key.

**Fetch archived items for collections with a status field**

For the same reasons, if you have "soft deleted" items and have some relations to these items, the migration tool may fail because of a relation with a deleted item (not imported). I added a check on a status field in imported collections to explicitly fetch items with all statuses (and also fixed the items counts).

<hr>

Feel free to review my code, I will update it if needed so it will be 💯 compliant.