### PR TITLE
Allow migation failures and improve error logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,13 @@ const commandLineOptions = commandLineArgs([
     multiple: false,
     defaultValue: "./context/start.json",
   },
+  {
+    name: "allowFailures",
+    alias: "l",
+    type: Boolean,
+    multiple: false,
+    defaultValue: false,
+  },
 ]);
 
 const tasks = new Listr([
@@ -80,6 +87,7 @@ export async function writeContext(context, section) {
 }
 
 async function setupContext(context) {
+  context.allowFailures = commandLineOptions.allowFailures
   const contextJSON = await fs.promises.readFile(
     commandLineOptions.useContext,
     "utf8"

--- a/index.js
+++ b/index.js
@@ -9,106 +9,106 @@ import { migrateData } from "./tasks/data.js";
 import { migrateRelations } from "./tasks/relations.js";
 
 const commandLineOptions = commandLineArgs([
-  {
-    name: "skipCollections",
-    alias: "s",
-    type: String,
-    multiple: true,
-    defaultValue: [],
-  },
-  {
-    name: "useContext",
-    alias: "c",
-    type: String,
-    multiple: false,
-    defaultValue: "./context/start.json",
-  },
-  {
-    name: "allowFailures",
-    alias: "l",
-    type: Boolean,
-    multiple: false,
-    defaultValue: false,
-  },
+	{
+		name: "skipCollections",
+		alias: "s",
+		type: String,
+		multiple: true,
+		defaultValue: [],
+	},
+	{
+		name: "useContext",
+		alias: "c",
+		type: String,
+		multiple: false,
+		defaultValue: "./context/start.json",
+	},
+	{
+		name: "allowFailures",
+		alias: "l",
+		type: Boolean,
+		multiple: false,
+		defaultValue: false,
+	},
 ]);
 
 const tasks = new Listr([
-  {
-    title: "Loading context",
-    task: setupContext,
-  },
-  {
-    title: "Migrating Schema",
-    skip: (context) =>
-      context.completedSteps.schema === true &&
-      context.completedSteps.collections === true,
-    task: (context) => {
-      context.skipCollections = commandLineOptions.skipCollections;
-      return migrateSchema(context);
-    },
-  },
-  {
-    title: "Migration Files",
-    skip: (context) => context.completedSteps.files === true,
-    task: migrateFiles,
-  },
-  {
-    title: "Migrating Users",
-    skip: (context) =>
-      context.completedSteps.roles === true &&
-      context.completedSteps.users === true,
-    task: migrateUsers,
-  },
-  {
-    title: "Migrating Relations",
-    skip: (context) =>
-      context.completedSteps.relationsv8 === true &&
-      context.completedSteps.relations === true,
-    task: migrateRelations,
-  },
-  {
-    title: "Migrating Data",
-    skip: (context) => context.completedSteps.data === true,
-    task: migrateData,
-  },
+	{
+		title: "Loading context",
+		task: setupContext,
+	},
+	{
+		title: "Migrating Schema",
+		skip: (context) =>
+			context.completedSteps.schema === true &&
+			context.completedSteps.collections === true,
+		task: (context) => {
+			context.skipCollections = commandLineOptions.skipCollections;
+			return migrateSchema(context);
+		},
+	},
+	{
+		title: "Migration Files",
+		skip: (context) => context.completedSteps.files === true,
+		task: migrateFiles,
+	},
+	{
+		title: "Migrating Users",
+		skip: (context) =>
+			context.completedSteps.roles === true &&
+			context.completedSteps.users === true,
+		task: migrateUsers,
+	},
+	{
+		title: "Migrating Relations",
+		skip: (context) =>
+			context.completedSteps.relationsv8 === true &&
+			context.completedSteps.relations === true,
+		task: migrateRelations,
+	},
+	{
+		title: "Migrating Data",
+		skip: (context) => context.completedSteps.data === true,
+		task: migrateData,
+	},
 
-  {
-    title: "Save final context",
-    task: (context) => writeContext(context, "completed"),
-  },
+	{
+		title: "Save final context",
+		task: (context) => writeContext(context, "completed"),
+	},
 ]);
 
 export async function writeContext(context, section) {
-  context.completedSteps[section] = true;
-  await fs.promises.writeFile(
-    `./context/state/${section}.json`,
-    JSON.stringify(context)
-  );
+	context.completedSteps[section] = true;
+	await fs.promises.writeFile(
+		`./context/state/${section}.json`,
+		JSON.stringify(context)
+	);
 }
 
 async function setupContext(context) {
-  context.allowFailures = commandLineOptions.allowFailures
-  const contextJSON = await fs.promises.readFile(
-    commandLineOptions.useContext,
-    "utf8"
-  );
-  console.log("Loading context");
-  const fetchedContext = JSON.parse(contextJSON);
-  Object.entries(fetchedContext).forEach(([key, value]) => {
-    context[key] = value;
-  });
-  console.log(`✨ Loaded context succesfully`);
+	context.allowFailures = commandLineOptions.allowFailures;
+	const contextJSON = await fs.promises.readFile(
+		commandLineOptions.useContext,
+		"utf8"
+	);
+	console.log("Loading context");
+	const fetchedContext = JSON.parse(contextJSON);
+	Object.entries(fetchedContext).forEach(([key, value]) => {
+		context[key] = value;
+	});
+	console.log(`✨ Loaded context succesfully`);
 }
 
 console.log(
-  `✨ Migrating ${process.env.V8_URL} (v8) to ${process.env.V9_URL} (v9)...`
+	`✨ Migrating ${process.env.V8_URL} (v8) to ${process.env.V9_URL} (v9)...`
 );
 
 tasks
-  .run()
-  .then(() => {
-    console.log("✨ All set! Migration successful.");
-  })
-  .catch((err) => {
-    console.error(err);
-  });
+	.run()
+	.then(() => {
+		console.log("✨ All set! Migration successful.");
+	})
+	.catch((err) => {
+		console.error(err);
+	});

--- a/readme.md
+++ b/readme.md
@@ -4,30 +4,34 @@ Migrate from a v8 instance to v9 instance.
 
 This tool will copy over:
 
-* Schema (collections / fields)
-* Files (including file contents)
-* User data (eg all items in all collections)
-* Roles
-* Users
+- Schema (collections / fields)
+- Files (including file contents)
+- User data (eg all items in all collections)
+- Roles
+- Users
 
 **Note:** This tool will NOT copy over:
 
-* Interface/display configurations
-* Permissions
-* Activity / revisions
+- Interface/display configurations
+- Permissions
+- Activity / revisions
 
 ## Usage
 
-1) Clone this repo
-2) Add a .env file with the following values:
-***
+1. Clone this repo
+2. Add a .env file with the following values:
+
+---
+
 You SHOULD use either Cookie or JWT authentication (leaving one or the other empty).
 
 Using `Cookie Authentication` provides you with more time to migrate large amounts of data like the [project files](https://v8.docs.directus.io/guides/files.html#files-thumbnails).
 
 See [documentation](https://v8.docs.directus.io/api/authentication.html#tokens) for more details on obtaining
 authentication tokens on Directus v8.
-***
+
+---
+
 ```
 V8_URL="https://v8.example.com"
 V8_PROJECT_NAME="project"
@@ -37,33 +41,46 @@ V8_COOKIE_TOKEN="cookie_value"
 V9_URL="https://v9.example.com"
 V9_TOKEN="admin"
 ```
-3) Run `npm install`
-4) Run the `index.js` file: `node index.js`
+
+3. Run `npm install`
+4. Run the `index.js` file: `node index.js`
 
 Note: If you want to save the error logs to a folder, you can redirect the error output `node index.js 2> errors.txt`
 
 ### Commandline Options
-***
+
+---
+
 You can exclude collections/database tables from being migrated by using the `-s` or `--skipCollections` flag:
+
 ```
 node index.js -s <table_name> <another_table_name>
 ```
-***
+
+---
+
 You can pass a context file to resume from a specific point or to modify the data manually that you want to use for the migration by using the `-c` or `--useContext` flag:
+
 ```
 node index.js -c <path_to_context>
 ```
-***
+
+---
+
 You can allow errors to occur during the migration by using the `-l` or `--allowFailures` flag:
+
 ```
 node index.js -l
 ```
-***
+
+---
 
 ### Specifying collection dependencies
+
 If the default detection of the dependencies between collections doesn't work in your case, you can manually specify it with the env variable `COLLECTION_ORDER`. Just supply a comma separated list in which order you'd need the data of your collections to be imported.
 
 ```
 COLLECTION_ORDER="first_collection,second_collection,third_collection"
 ```
-***
+
+---

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,7 @@ V9_TOKEN="admin"
 3) Run `npm install`
 4) Run the `index.js` file: `node index.js`
 
+Note: If you want to save the error logs to a folder, you can redirect the error output `node index.js 2> errors.txt`
 
 ### Commandline Options
 ***
@@ -51,6 +52,11 @@ node index.js -s <table_name> <another_table_name>
 You can pass a context file to resume from a specific point or to modify the data manually that you want to use for the migration by using the `-c` or `--useContext` flag:
 ```
 node index.js -c <path_to_context>
+```
+***
+You can allow errors to occur during the migration by using the `-l` or `--allowFailures` flag:
+```
+node index.js -l
 ```
 ***
 

--- a/tasks/data.js
+++ b/tasks/data.js
@@ -208,7 +208,7 @@ async function insertBatch(collection, page, context, task) {
 			await apiV9.post(`/items/${collection.collection}`, itemRecords);
 		}
 	} catch (err) {
-		console.error(collection.collection, err.response?.data);
+		console.error(`Error migrating data for collection [${collection.collection}], response: ${JSON.stringify(err.response?.data, null, 2)}`);
     if (!context.allowFailures) {
       throw Error("Data migration failed. Check directus logs for most insight.")
     }

--- a/tasks/data.js
+++ b/tasks/data.js
@@ -18,17 +18,19 @@ async function getCounts(context) {
 	context.counts = {};
 
 	for (const collection of context.collections) {
-		const contextCollection = context.collectionsV9.find(c => c.collection === collection.collection)
+		const contextCollection = context.collectionsV9.find(
+			(c) => c.collection === collection.collection
+		);
 
-		let hasStatus = false
+		let hasStatus = false;
 		const params = {
 			limit: 1,
 			meta: "total_count",
-		}
+		};
 
 		if (contextCollection && contextCollection?.meta?.archive_value) {
-			hasStatus = true
-			params.meta = '*'
+			hasStatus = true;
+			params.meta = "*";
 		}
 
 		const count = await apiV8.get(`/items/${collection.collection}`, {
@@ -36,8 +38,9 @@ async function getCounts(context) {
 		});
 
 		if (hasStatus) {
-			context.counts[collection.collection] = Object.keys(count.data.meta.status_count)
-				.reduce((acc, cur) => acc + count.data.meta.status_count[cur], 0);
+			context.counts[collection.collection] = Object.keys(
+				count.data.meta.status_count
+			).reduce((acc, cur) => acc + count.data.meta.status_count[cur], 0);
 		} else {
 			context.counts[collection.collection] = count.data.meta.total_count;
 		}
@@ -72,7 +75,7 @@ function isJunctionCollection(note) {
 
 // This is definitely a hack to achieve first adding items of collections that have dependencies in other collections i.e m2m, o2m
 // FIXME: Implement a more robust solution to sort collections based on their dependencies, or swap to a different way to seed the data
-function moveJunctionCollectionsBack(a,b) {
+function moveJunctionCollectionsBack(a, b) {
 	if (isJunctionCollection(a.note) || isJunctionCollection(b.note)) {
 		if (isJunctionCollection(a.note)) {
 			return 1;
@@ -86,12 +89,20 @@ function moveJunctionCollectionsBack(a,b) {
 	return 0;
 }
 
-function moveManyToOne(a,b) {
-	if ( Object.values(a.fields).find(element => element.interface === 'many-to-one') ) {
+function moveManyToOne(a, b) {
+	if (
+		Object.values(a.fields).find(
+			(element) => element.interface === "many-to-one"
+		)
+	) {
 		return 1;
 	}
 
-	if ( Object.values(b.fields).find(element => element.interface === 'many-to-one') ) {
+	if (
+		Object.values(b.fields).find(
+			(element) => element.interface === "many-to-one"
+		)
+	) {
 		return -1;
 	}
 
@@ -100,23 +111,27 @@ function moveManyToOne(a,b) {
 
 function moveByCustomOrder(collectionOrder) {
 	return (a, b) => {
-		return collectionOrder.indexOf(a.collection) - collectionOrder.indexOf(b.collection);
-	}
+		return (
+			collectionOrder.indexOf(a.collection) -
+			collectionOrder.indexOf(b.collection)
+		);
+	};
 }
 
 async function insertData(context) {
 	let sortedCollections;
 
 	if (process.env.COLLECTION_ORDER) {
-		const collectionOrder = process.env.COLLECTION_ORDER
-			.split(',')
-			.map(entry => entry.trim());
-		sortedCollections = context.collections
-			.sort(moveByCustomOrder(collectionOrder))
+		const collectionOrder = process.env.COLLECTION_ORDER.split(",").map(
+			(entry) => entry.trim()
+		);
+		sortedCollections = context.collections.sort(
+			moveByCustomOrder(collectionOrder)
+		);
 	} else {
 		sortedCollections = context.collections
 			.sort(moveManyToOne)
-			.sort(moveJunctionCollectionsBack)
+			.sort(moveJunctionCollectionsBack);
 	}
 
 	return new Listr(
@@ -141,22 +156,24 @@ function insertCollection(collection) {
 }
 
 async function insertBatch(collection, page, context, task) {
-	const contextCollection = context.collectionsV9.find(c => c.collection === collection.collection)
+	const contextCollection = context.collectionsV9.find(
+		(c) => c.collection === collection.collection
+	);
 
 	const getRecordsResponse = () => {
 		const params = {
 			offset: page * 100,
 			limit: 100,
-		}
+		};
 
 		if (contextCollection && contextCollection?.meta?.archive_value) {
-			params.status = '*'
+			params.status = "*";
 		}
 
 		return apiV8.get(`/items/${collection.collection}`, {
 			params,
 		});
-	}
+	};
 
 	let recordsResponse;
 
@@ -175,7 +192,9 @@ async function insertBatch(collection, page, context, task) {
 		);
 	});
 
-	const datetimeFields = Object.values(collection.fields).filter(field => field.type === 'datetime')
+	const datetimeFields = Object.values(collection.fields).filter(
+		(field) => field.type === "datetime"
+	);
 
 	const itemRecords =
 		systemRelationsForCollection.length === 0 && datetimeFields.length === 0
@@ -185,17 +204,23 @@ async function insertBatch(collection, page, context, task) {
 						if (systemRelation?.meta?.one_collection === "directus_users") {
 							item[systemRelation?.meta?.many_field] =
 								context.userMap[item[systemRelation?.meta?.many_field]];
-						} else if (systemRelation?.meta?.one_collection === "directus_files") {
+						} else if (
+							systemRelation?.meta?.one_collection === "directus_files"
+						) {
 							item[systemRelation?.meta?.many_field] =
 								context.fileMap[item[systemRelation?.meta?.many_field]];
-						} else if (systemRelation?.meta?.one_collection === "directus_roles") {
+						} else if (
+							systemRelation?.meta?.one_collection === "directus_roles"
+						) {
 							item[systemRelation?.meta?.many_field] =
 								context.roleMap[item[systemRelation?.meta?.many_field]];
 						}
 					}
 
 					for (const datetimeField of datetimeFields) {
-						item[datetimeField.field] = new Date(item[datetimeField.field]).toISOString();
+						item[datetimeField.field] = new Date(
+							item[datetimeField.field]
+						).toISOString();
 					}
 
 					return item;
@@ -208,10 +233,16 @@ async function insertBatch(collection, page, context, task) {
 			await apiV9.post(`/items/${collection.collection}`, itemRecords);
 		}
 	} catch (err) {
-		console.error(`Error migrating data for collection [${collection.collection}], response: ${JSON.stringify(err.response?.data, null, 2)}`);
-    if (!context.allowFailures) {
-      throw Error("Data migration failed. Check directus logs for most insight.")
-    }
+		console.error(
+			`Error migrating data for collection [${
+				collection.collection
+			}], response: ${JSON.stringify(err.response?.data, null, 2)}`
+		);
+		if (!context.allowFailures) {
+			throw Error(
+				"Data migration failed. Check directus logs for most insight."
+			);
+		}
 	}
 }
 

--- a/tasks/data.js
+++ b/tasks/data.js
@@ -209,7 +209,9 @@ async function insertBatch(collection, page, context, task) {
 		}
 	} catch (err) {
 		console.log(err.response.data);
-		throw Error("Data migration failed. Check directus logs for most insight.")
+    if (!context.allowFailures) {
+      throw Error("Data migration failed. Check directus logs for most insight.")
+    }
 	}
 }
 

--- a/tasks/data.js
+++ b/tasks/data.js
@@ -208,7 +208,7 @@ async function insertBatch(collection, page, context, task) {
 			await apiV9.post(`/items/${collection.collection}`, itemRecords);
 		}
 	} catch (err) {
-		console.log(err.response.data);
+		console.error(collection.collection, err.response?.data);
     if (!context.allowFailures) {
       throw Error("Data migration failed. Check directus logs for most insight.")
     }

--- a/tasks/files.js
+++ b/tasks/files.js
@@ -80,7 +80,7 @@ function uploadBatch(page) {
 
         context.fileMap[fileRecord.id] = savedFile.data.data.id;
       } catch (err) {
-        console.log(err.response.data);
+        console.error(fileRecord.id, err.response?.data);
         if (!context.allowFailures) {
           throw Error("File migration failed. Check directus logs for most insight.")
         }

--- a/tasks/files.js
+++ b/tasks/files.js
@@ -13,9 +13,9 @@ export async function migrateFiles(context) {
 			task: uploadFiles,
 		},
 		{
-      title: "Saving context",
-      task: () => writeContext(context, "files")
-    },
+			title: "Saving context",
+			task: () => writeContext(context, "files"),
+		},
 	]);
 }
 
@@ -59,7 +59,8 @@ function uploadBatch(page) {
 			task.output = fileRecord.filename_download;
 			let url;
 			if (fileRecord.data.asset_url) {
-				url = process.env.V8_URL +
+				url =
+					process.env.V8_URL +
 					"/" +
 					process.env.V8_PROJECT_NAME +
 					"/" +
@@ -68,23 +69,29 @@ function uploadBatch(page) {
 				url = fileRecord.data.full_url;
 			}
 
-      try {
-        const savedFile = await apiV9.post("/files/import", {
-          url,
-          data: {
-            filename_download: fileRecord.filename_download,
-            title: fileRecord.title,
-            description: fileRecord.description,
-          },
-        });
+			try {
+				const savedFile = await apiV9.post("/files/import", {
+					url,
+					data: {
+						filename_download: fileRecord.filename_download,
+						title: fileRecord.title,
+						description: fileRecord.description,
+					},
+				});
 
-        context.fileMap[fileRecord.id] = savedFile.data.data.id;
-      } catch (err) {
-        console.error(`Error migrating file with id [${fileRecord.id}], response: ${JSON.stringify(err.response?.data, null, 2)}`);
-        if (!context.allowFailures) {
-          throw Error("File migration failed. Check directus logs for most insight.")
-        }
-      }
+				context.fileMap[fileRecord.id] = savedFile.data.data.id;
+			} catch (err) {
+				console.error(
+					`Error migrating file with id [${
+						fileRecord.id
+					}], response: ${JSON.stringify(err.response?.data, null, 2)}`
+				);
+				if (!context.allowFailures) {
+					throw Error(
+						"File migration failed. Check directus logs for most insight."
+					);
+				}
+			}
 		}
 	};
 }

--- a/tasks/files.js
+++ b/tasks/files.js
@@ -68,16 +68,23 @@ function uploadBatch(page) {
 				url = fileRecord.data.full_url;
 			}
 
-			const savedFile = await apiV9.post("/files/import", {
-				url,
-				data: {
-					filename_download: fileRecord.filename_download,
-					title: fileRecord.title,
-					description: fileRecord.description,
-				},
-			});
+      try {
+        const savedFile = await apiV9.post("/files/import", {
+          url,
+          data: {
+            filename_download: fileRecord.filename_download,
+            title: fileRecord.title,
+            description: fileRecord.description,
+          },
+        });
 
-			context.fileMap[fileRecord.id] = savedFile.data.data.id;
+        context.fileMap[fileRecord.id] = savedFile.data.data.id;
+      } catch (err) {
+        console.log(err.response.data);
+        if (!context.allowFailures) {
+          throw Error("File migration failed. Check directus logs for most insight.")
+        }
+      }
 		}
 	};
 }

--- a/tasks/files.js
+++ b/tasks/files.js
@@ -80,7 +80,7 @@ function uploadBatch(page) {
 
         context.fileMap[fileRecord.id] = savedFile.data.data.id;
       } catch (err) {
-        console.error(fileRecord.id, err.response?.data);
+        console.error(`Error migrating file with id [${fileRecord.id}], response: ${JSON.stringify(err.response?.data, null, 2)}`);
         if (!context.allowFailures) {
           throw Error("File migration failed. Check directus logs for most insight.")
         }

--- a/tasks/schema.js
+++ b/tasks/schema.js
@@ -5,315 +5,331 @@ import { interfaceMap } from "../constants/interface-map.js";
 import { writeContext } from "../index.js";
 
 export async function migrateSchema(context) {
-  return new Listr([
-    {
-      title: "Downloading Schema",
-      skip: context => context.completedSteps.schema === true,
-      task: () => downloadSchema(context),
-    },
-    {
-      title: "Saving schema context",
-      skip: context => context.completedSteps.schema === true,
-      task: () => writeContext(context, "schema")
-    },
-    {
-      title: "Creating Collections",
-      skip: context => context.completedSteps.collections === true,
-      task: () => migrateCollections(context),
-    },
-    {
-      title: "Saving collections context",
-      skip: context => context.completedSteps.collections === true,
-      task: () => writeContext(context, "collections")
-    },
-  ]);
+	return new Listr([
+		{
+			title: "Downloading Schema",
+			skip: (context) => context.completedSteps.schema === true,
+			task: () => downloadSchema(context),
+		},
+		{
+			title: "Saving schema context",
+			skip: (context) => context.completedSteps.schema === true,
+			task: () => writeContext(context, "schema"),
+		},
+		{
+			title: "Creating Collections",
+			skip: (context) => context.completedSteps.collections === true,
+			task: () => migrateCollections(context),
+		},
+		{
+			title: "Saving collections context",
+			skip: (context) => context.completedSteps.collections === true,
+			task: () => writeContext(context, "collections"),
+		},
+	]);
 }
 
 async function downloadSchema(context) {
-  const response = await apiV8.get("/collections");
-  context.collections = response.data.data.filter(
-    (collection) => collection.collection.startsWith("directus_") === false
-  ).filter(
-    (collection) => !context.skipCollections.includes(collection.collection)
-  );
+	const response = await apiV8.get("/collections");
+	context.collections = response.data.data
+		.filter(
+			(collection) => collection.collection.startsWith("directus_") === false
+		)
+		.filter(
+			(collection) => !context.skipCollections.includes(collection.collection)
+		);
 }
 
 async function migrateCollections(context) {
-  return new Listr(
-    context.collections
-      .map((collection) => ({
-        title: collection.collection,
-        task: migrateCollection(collection, context),
-      }))
-  );
+	return new Listr(
+		context.collections.map((collection) => ({
+			title: collection.collection,
+			task: migrateCollection(collection, context),
+		}))
+	);
 }
 
 function migrateFieldOptions(fieldDetails) {
-  if (fieldDetails.interface === "divider") {
-    return {
-      title: fieldDetails.options.title,
-      marginTop: fieldDetails.options.margin,
-    };
-  }
+	if (fieldDetails.interface === "divider") {
+		return {
+			title: fieldDetails.options.title,
+			marginTop: fieldDetails.options.margin,
+		};
+	}
 
-  if (fieldDetails.interface === "status") {
-    return {
-      choices: Object.values(fieldDetails.options.status_mapping).map(
-        ({ name, value }) => ({
-          text: name,
-          value: value,
-        })
-      ),
-    };
-  }
+	if (fieldDetails.interface === "status") {
+		return {
+			choices: Object.values(fieldDetails.options.status_mapping).map(
+				({ name, value }) => ({
+					text: name,
+					value: value,
+				})
+			),
+		};
+	}
 
-  if (fieldDetails.interface === "dropdown") {
-    return {
-      choices: Object.entries(fieldDetails.options.choices).map(
-        ([value, text]) => ({
-          text,
-          value,
-        })
-      ),
-      placeholder: fieldDetails.options.placeholder,
-    };
-  }
+	if (fieldDetails.interface === "dropdown") {
+		return {
+			choices: Object.entries(fieldDetails.options.choices).map(
+				([value, text]) => ({
+					text,
+					value,
+				})
+			),
+			placeholder: fieldDetails.options.placeholder,
+		};
+	}
 
-  if (fieldDetails.interface === "repeater" && fieldDetails.options.dataType === "object") {
-    const fieldKeys = Object.keys(fieldDetails.options.fields)
-    const fields = fieldDetails.options.fields
-    return {
-      fields: fieldKeys.map((field) => ({
-        name: field,
-        type: fields[field].type,
-        field: field,
-        meta: {
-          name: field,
-          type: fields[field].type,
-          field: field,
-          width: fields[field].width,
-          interface: fields[field].interface,
-          options: migrateFieldOptions(field),
-        },
-      })),
-    };
-  }
+	if (
+		fieldDetails.interface === "repeater" &&
+		fieldDetails.options.dataType === "object"
+	) {
+		const fieldKeys = Object.keys(fieldDetails.options.fields);
+		const fields = fieldDetails.options.fields;
+		return {
+			fields: fieldKeys.map((field) => ({
+				name: field,
+				type: fields[field].type,
+				field: field,
+				meta: {
+					name: field,
+					type: fields[field].type,
+					field: field,
+					width: fields[field].width,
+					interface: fields[field].interface,
+					options: migrateFieldOptions(field),
+				},
+			})),
+		};
+	}
 
-  if (fieldDetails.interface === "repeater") {
-    return {
-      fields: fieldDetails.options.fields.map((field) => ({
-        name: field.field,
-        type: field.type,
-        field: field.field,
-        meta: {
-          name: field.field,
-          type: field.type,
-          field: field.field,
-          width: field.width,
-          interface: field.interface,
-          options: migrateFieldOptions(field),
-        },
-      })),
-    };
-  }
+	if (fieldDetails.interface === "repeater") {
+		return {
+			fields: fieldDetails.options.fields.map((field) => ({
+				name: field.field,
+				type: field.type,
+				field: field.field,
+				meta: {
+					name: field.field,
+					type: field.type,
+					field: field.field,
+					width: field.width,
+					interface: field.interface,
+					options: migrateFieldOptions(field),
+				},
+			})),
+		};
+	}
 
-  if (fieldDetails.interface === "checkboxes") {
-    return {
-      choices: Object.entries(fieldDetails.options.choices).map(
-        ([value, text]) => ({
-          text,
-          value,
-        })
-      ),
-      allowOther: fieldDetails.options.allow_other
-    };
-  }
+	if (fieldDetails.interface === "checkboxes") {
+		return {
+			choices: Object.entries(fieldDetails.options.choices).map(
+				([value, text]) => ({
+					text,
+					value,
+				})
+			),
+			allowOther: fieldDetails.options.allow_other,
+		};
+	}
 
-  if (fieldDetails.interface === "input-rich-text-html") {
-    return fieldDetails.options;
-  }
+	if (fieldDetails.interface === "input-rich-text-html") {
+		return fieldDetails.options;
+	}
 
-  if (fieldDetails.interface === "many-to-one") {
-    let obj = {};
-    if (fieldDetails.options.template) {
-      obj.template = fieldDetails.options.template;
-    }
-    return obj || null;
-  }
+	if (fieldDetails.interface === "many-to-one") {
+		let obj = {};
+		if (fieldDetails.options.template) {
+			obj.template = fieldDetails.options.template;
+		}
+		return obj || null;
+	}
 
-  if (fieldDetails.interface === "many-to-many") {
-    let obj = {};
-    if (fieldDetails.options.template) {
-      let templateWithoutBraces = fieldDetails.options.template.replace('{{', '').replace('}}', '').trim();
-      obj.template = "{{"+ fieldDetails.field + "_id." + templateWithoutBraces + "}}";
-    }
-    if (fieldDetails.options.allow_create) {
-      obj.enableCreate = fieldDetails.options.allow_create;
-    }
-    if (fieldDetails.options.allow_select) {
-      obj.enableSelect = fieldDetails.options.allow_select;
-    }
-    return obj || null;
-  }
+	if (fieldDetails.interface === "many-to-many") {
+		let obj = {};
+		if (fieldDetails.options.template) {
+			let templateWithoutBraces = fieldDetails.options.template
+				.replace("{{", "")
+				.replace("}}", "")
+				.trim();
+			obj.template =
+				"{{" + fieldDetails.field + "_id." + templateWithoutBraces + "}}";
+		}
+		if (fieldDetails.options.allow_create) {
+			obj.enableCreate = fieldDetails.options.allow_create;
+		}
+		if (fieldDetails.options.allow_select) {
+			obj.enableSelect = fieldDetails.options.allow_select;
+		}
+		return obj || null;
+	}
 }
 
 function migrateCollection(collection, context) {
-  return async () => {
-    const statusField = Object.values(collection.fields).find(
-      (field) => field.interface === "status"
-    );
+	return async () => {
+		const statusField = Object.values(collection.fields).find(
+			(field) => field.interface === "status"
+		);
 
-    const collectionV9 = {
-      collection: collection.collection,
-      meta: {
-        note: collection.note,
-        hidden: collection.hidden,
-        singleton: collection.single,
-        icon: collection.icon,
-        translations: collection.translation?.map(
-          ({ locale, translation }) => ({
-            language: locale,
-            translation,
-          })
-        ),
-        sort_field:
-          Object.entries(collection.fields).find(([field, details]) => {
-            return (details.type || "").toLowerCase() === "sort";
-          })?.field || null,
-        ...(statusField
-          ? {
-              archive_field: statusField.field,
-              archive_value: Object.values(
-                statusField.options.status_mapping
-              ).find((option) => option.soft_delete).value,
-              unarchive_value: Object.values(
-                statusField.options.status_mapping
-              ).find((option) => !option.soft_delete && !option.published)
-                .value,
-            }
-          : {}),
-      },
-      schema: {},
-      fields: Object.values(collection.fields).map((details) => {
-        return {
-          field: details.field,
-          type:
-            details.datatype?.toLowerCase() === "text" ||
-            details.datatype?.toLowerCase() === "longtext"
-              ? "text"
-              : details.interface === "many-to-many"
-              ? "m2m"
-              : details.field.includes("directus_files_id") || details.interface === 'user-roles'
-              ? "uuid"
-              : typeMap[details.type.toLowerCase()],
-          meta: {
-            note: details.note,
-            interface: interfaceMap[(details.interface || "").toLowerCase()],
-            translations: details.translation?.map(
-              ({ locale, translation }) => ({
-                language: locale,
-                translation,
-              })
-            ),
-            readonly: details.readonly,
-            hidden: details.hidden_detail,
-            width: details.width,
-            special: extractSpecial(details),
-            sort: details.sort,
-            options: migrateFieldOptions(details),
-          },
-          schema:
-            ["alias", "o2m"].includes(typeMap[details.type.toLowerCase()]) ===
-            false
-              ? {
-                  has_auto_increment: details.auto_increment,
-                  default_value: extractValue(details),
-                  is_primary_key: details.primary_key,
-                  is_nullable: details.required === false,
-                  max_length: details.length,
-                  numeric_precision:
-                    (details.length || "").split(",")[0] || null,
-                  numeric_scale: (details.length || "").split(",")[1] || null,
-                }
-              : undefined,
-        };
-      }),
-    };
-    context.collectionsV9.push(collectionV9);
-    try {
-      await apiV9.post("/collections", collectionV9);
-    } catch (err) {
-      console.error(`Error migrating schema for collection [${collectionV9.collection}], response: ${JSON.stringify(err.response?.data, null, 2)}`);
-      if (!context.allowFailures) {
-        throw Error("Schema migration failed. Check directus logs for most insight.")
-      }
-    }
-  };
+		const collectionV9 = {
+			collection: collection.collection,
+			meta: {
+				note: collection.note,
+				hidden: collection.hidden,
+				singleton: collection.single,
+				icon: collection.icon,
+				translations: collection.translation?.map(
+					({ locale, translation }) => ({
+						language: locale,
+						translation,
+					})
+				),
+				sort_field:
+					Object.entries(collection.fields).find(([field, details]) => {
+						return (details.type || "").toLowerCase() === "sort";
+					})?.field || null,
+				...(statusField
+					? {
+							archive_field: statusField.field,
+							archive_value: Object.values(
+								statusField.options.status_mapping
+							).find((option) => option.soft_delete).value,
+							unarchive_value: Object.values(
+								statusField.options.status_mapping
+							).find((option) => !option.soft_delete && !option.published)
+								.value,
+					  }
+					: {}),
+			},
+			schema: {},
+			fields: Object.values(collection.fields).map((details) => {
+				return {
+					field: details.field,
+					type:
+						details.datatype?.toLowerCase() === "text" ||
+						details.datatype?.toLowerCase() === "longtext"
+							? "text"
+							: details.interface === "many-to-many"
+							? "m2m"
+							: details.field.includes("directus_files_id") ||
+							  details.interface === "user-roles"
+							? "uuid"
+							: typeMap[details.type.toLowerCase()],
+					meta: {
+						note: details.note,
+						interface: interfaceMap[(details.interface || "").toLowerCase()],
+						translations: details.translation?.map(
+							({ locale, translation }) => ({
+								language: locale,
+								translation,
+							})
+						),
+						readonly: details.readonly,
+						hidden: details.hidden_detail,
+						width: details.width,
+						special: extractSpecial(details),
+						sort: details.sort,
+						options: migrateFieldOptions(details),
+					},
+					schema:
+						["alias", "o2m"].includes(typeMap[details.type.toLowerCase()]) ===
+						false
+							? {
+									has_auto_increment: details.auto_increment,
+									default_value: extractValue(details),
+									is_primary_key: details.primary_key,
+									is_nullable: details.required === false,
+									max_length: details.length,
+									numeric_precision:
+										(details.length || "").split(",")[0] || null,
+									numeric_scale: (details.length || "").split(",")[1] || null,
+							  }
+							: undefined,
+				};
+			}),
+		};
+		context.collectionsV9.push(collectionV9);
+		try {
+			await apiV9.post("/collections", collectionV9);
+		} catch (err) {
+			console.error(
+				`Error migrating schema for collection [${
+					collectionV9.collection
+				}], response: ${JSON.stringify(err.response?.data, null, 2)}`
+			);
+			if (!context.allowFailures) {
+				throw Error(
+					"Schema migration failed. Check directus logs for most insight."
+				);
+			}
+		}
+	};
 
-  function extractValue(details) {
-    if (typeMap[details.type.toLowerCase()] === "json") {
-      try {
-        JSON.parse(details.default_value);
-      } catch (ex) {
-        return JSON.stringify(details.default_value);
-      }
-    }
+	function extractValue(details) {
+		if (typeMap[details.type.toLowerCase()] === "json") {
+			try {
+				JSON.parse(details.default_value);
+			} catch (ex) {
+				return JSON.stringify(details.default_value);
+			}
+		}
 
-    return details.default_value;
-  }
+		return details.default_value;
+	}
 
-  function extractSpecial(details) {
-    const type = details.interface === "many-to-many" ? "m2m" : details.type.toLowerCase();
-    if (type === "alias") {
-      return ["alias", "no-data"];
-    }
+	function extractSpecial(details) {
+		const type =
+			details.interface === "many-to-many" ? "m2m" : details.type.toLowerCase();
+		if (type === "alias") {
+			return ["alias", "no-data"];
+		}
 
-    if (type === "boolean") {
-      return ["boolean"];
-    }
+		if (type === "boolean") {
+			return ["boolean"];
+		}
 
-    if (type === "hash") {
-      return ["hash"];
-    }
+		if (type === "hash") {
+			return ["hash"];
+		}
 
-    if (type === "json") {
-      return ["json"];
-    }
+		if (type === "json") {
+			return ["json"];
+		}
 
-    if (type === "uuid") {
-      return ["uuid"];
-    }
+		if (type === "uuid") {
+			return ["uuid"];
+		}
 
-    if (type === "owner") {
-      return ["user-created"];
-    }
+		if (type === "owner") {
+			return ["user-created"];
+		}
 
-    if (type === "user_updated") {
-      return ["user-updated"];
-    }
+		if (type === "user_updated") {
+			return ["user-updated"];
+		}
 
-    if (type === "datetime_created") {
-      return ["date-created"];
-    }
+		if (type === "datetime_created") {
+			return ["date-created"];
+		}
 
-    if (type === "datetime_updated") {
-      return ["date-updated"];
-    }
+		if (type === "datetime_updated") {
+			return ["date-updated"];
+		}
 
-    if (type === "csv") {
-      return ["csv"];
-    }
+		if (type === "csv") {
+			return ["csv"];
+		}
 
-    if (type === "o2m") {
-      return ["o2m"];
-    }
+		if (type === "o2m") {
+			return ["o2m"];
+		}
 
-    if (type === "m2m") {
-      return ["m2m"];
-    }
+		if (type === "m2m") {
+			return ["m2m"];
+		}
 
-    if (type === "m2o") {
-      return ["m2o"];
-    }
-  }
+		if (type === "m2o") {
+			return ["m2o"];
+		}
+	}
 }

--- a/tasks/schema.js
+++ b/tasks/schema.js
@@ -243,7 +243,7 @@ function migrateCollection(collection, context) {
     try {
       await apiV9.post("/collections", collectionV9);
     } catch (err) {
-      console.log(err.response.data);
+      console.error(collectionV9.collection, err.response?.data);
       if (!context.allowFailures) {
         throw Error("Schema migration failed. Check directus logs for most insight.")
       }

--- a/tasks/schema.js
+++ b/tasks/schema.js
@@ -78,7 +78,7 @@ function migrateFieldOptions(fieldDetails) {
       placeholder: fieldDetails.options.placeholder,
     };
   }
-  
+
   if (fieldDetails.interface === "repeater" && fieldDetails.options.dataType === "object") {
     const fieldKeys = Object.keys(fieldDetails.options.fields)
     const fields = fieldDetails.options.fields
@@ -98,7 +98,7 @@ function migrateFieldOptions(fieldDetails) {
       })),
     };
   }
-  
+
   if (fieldDetails.interface === "repeater") {
     return {
       fields: fieldDetails.options.fields.map((field) => ({
@@ -240,7 +240,14 @@ function migrateCollection(collection, context) {
       }),
     };
     context.collectionsV9.push(collectionV9);
-    await apiV9.post("/collections", collectionV9);
+    try {
+      await apiV9.post("/collections", collectionV9);
+    } catch (err) {
+      console.log(err.response.data);
+      if (!context.allowFailures) {
+        throw Error("Schema migration failed. Check directus logs for most insight.")
+      }
+    }
   };
 
   function extractValue(details) {

--- a/tasks/schema.js
+++ b/tasks/schema.js
@@ -243,7 +243,7 @@ function migrateCollection(collection, context) {
     try {
       await apiV9.post("/collections", collectionV9);
     } catch (err) {
-      console.error(collectionV9.collection, err.response?.data);
+      console.error(`Error migrating schema for collection [${collectionV9.collection}], response: ${JSON.stringify(err.response?.data, null, 2)}`);
       if (!context.allowFailures) {
         throw Error("Schema migration failed. Check directus logs for most insight.")
       }


### PR DESCRIPTION
The improved errors help quite a lot, and the flag is useful if you're having issues with some specific tables - it allows you to carry on and not block yourself there.

Note: it looks bad formatted, but the editor is showing it correctly. We can add a .editorconfig and unify formatting in another MR to avoid these issues.